### PR TITLE
Feat/better resource names

### DIFF
--- a/assets/security_ir_poller/index.py
+++ b/assets/security_ir_poller/index.py
@@ -367,10 +367,10 @@ def get_incident_response_team_members() -> List[Dict[str, str]]:
         logger.debug(f"Discovered active membership ID: {membership_id}")
 
         membership = security_ir_client.get_membership(membershipId=membership_id)
-        team_members = membership.get("incidentResponseTeam", [])
-        logger.info(f"Retrieved {len(team_members)} incident response team members from membership {membership_id}")
+        ir_team_members = membership.get("incidentResponseTeam", [])
+        logger.info(f"Retrieved {len(ir_team_members)} incident response team members from membership {membership_id}")
 
-        return team_members
+        return ir_team_members
 
     except Exception as e:
         logger.error(f"Error fetching membership team members: {str(e)}")

--- a/aws_security_incident_response_sample_integrations/aws_security_incident_response_sample_integrations_common_stack.py
+++ b/aws_security_incident_response_sample_integrations/aws_security_incident_response_sample_integrations_common_stack.py
@@ -112,7 +112,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.domain_layer = aws_lambda.LayerVersion(
             self,
             "DomainLayer",
-            layer_name="security-incident-response-domain-layer",
+            layer_version_name="security-incident-response-domain-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/domain"),
             ),
@@ -123,7 +123,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.mappers_layer = aws_lambda.LayerVersion(
             self,
             "MappersLayer",
-            layer_name="security-incident-response-mappers-layer",
+            layer_version_name="security-incident-response-mappers-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/mappers"),
             ),
@@ -134,7 +134,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.wrappers_layer = aws_lambda.LayerVersion(
             self,
             "WrappersLayer",
-            layer_name="security-incident-response-wrappers-layer",
+            layer_version_name="security-incident-response-wrappers-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/wrappers"),
             ),

--- a/aws_security_incident_response_sample_integrations/aws_security_incident_response_sample_integrations_common_stack.py
+++ b/aws_security_incident_response_sample_integrations/aws_security_incident_response_sample_integrations_common_stack.py
@@ -76,6 +76,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.table = dynamodb.Table(
             self,
             "IncidentsTable",
+            table_name="security-incident-response-incidents-table",
             partition_key=dynamodb.Attribute(
                 name="PK", type=dynamodb.AttributeType.STRING
             ),
@@ -111,6 +112,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.domain_layer = aws_lambda.LayerVersion(
             self,
             "DomainLayer",
+            layer_name="security-incident-response-domain-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/domain"),
             ),
@@ -121,6 +123,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.mappers_layer = aws_lambda.LayerVersion(
             self,
             "MappersLayer",
+            layer_name="security-incident-response-mappers-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/mappers"),
             ),
@@ -131,6 +134,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.wrappers_layer = aws_lambda.LayerVersion(
             self,
             "WrappersLayer",
+            layer_name="security-incident-response-wrappers-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/wrappers"),
             ),
@@ -145,6 +149,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         poller_role = aws_iam.Role(
             self,
             "SecurityIncidentResponsePollerRole",
+            role_name="security-incident-response-poller-role",
             assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
             description="Custom role for Security Incident Response Poller Lambda function",
         )
@@ -158,6 +163,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         poller_logs = aws_logs.LogGroup(
             self,
             "SecurityIncidentResponsePollerLogGroup",
+            log_group_name="/aws/lambda/security-incident-response-poller",
             retention=aws_logs.RetentionDays.ONE_WEEK,
             removal_policy=RemovalPolicy.DESTROY,
         )
@@ -166,6 +172,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.poller = py_lambda.PythonFunction(
             self,
             "SecurityIncidentResponsePoller",
+            function_name="security-incident-response-poller-function",
             entry=path.join(path.dirname(__file__), "..", "assets/security_ir_poller"),
             runtime=aws_lambda.Runtime.PYTHON_3_13,
             timeout=Duration.minutes(15),
@@ -185,6 +192,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.poller_rule = aws_events.Rule(
             self,
             "SecurityIncidentResponsePollerRule",
+            rule_name="security-incident-response-poller-schedule",
             schedule=aws_events.Schedule.rate(duration=Duration.minutes(1)),
             targets=[aws_events_targets.LambdaFunction(self.poller)],
             enabled=False,  # Start disabled
@@ -250,6 +258,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         security_ir_client_role = aws_iam.Role(
             self,
             "SecurityIncidentResponseClientRole",
+            role_name="security-incident-response-client-role",
             assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
             description="Custom role for Security Incident Response Client Lambda function",
         )
@@ -288,6 +297,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         self.security_ir_client = py_lambda.PythonFunction(
             self,
             "SecurityIncidentResponseClient",
+            function_name="security-incident-response-client-function",
             entry=path.join(path.dirname(__file__), "..", "assets/security_ir_client"),
             runtime=aws_lambda.Runtime.PYTHON_3_13,
             timeout=Duration.minutes(15),
@@ -303,6 +313,7 @@ class AwsSecurityIncidentResponseSampleIntegrationsCommonStack(Stack):
         security_ir_client_rule = aws_events.Rule(
             self,
             "security-ir-client-rule",
+            rule_name="security-incident-response-client-rule",
             description="Rule to send all events to Security Incident Response Client lambda function",
             event_pattern=aws_events.EventPattern(
                 source=[JIRA_EVENT_SOURCE, SERVICE_NOW_EVENT_SOURCE, SLACK_EVENT_SOURCE]

--- a/aws_security_incident_response_sample_integrations/aws_security_incident_response_slack_integration_stack.py
+++ b/aws_security_incident_response_sample_integrations/aws_security_incident_response_slack_integration_stack.py
@@ -119,6 +119,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_bolt_layer = aws_lambda.LayerVersion(
             self,
             "SlackBoltLayer",
+            layer_name="security-incident-response-slack-bolt-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/slack_bolt_layer"),
             ),
@@ -133,6 +134,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_client_role = aws_iam.Role(
             self,
             "SecurityIncidentResponseSlackClientRole",
+            role_name="security-incident-response-slack-client-role",
             assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
             description="Custom role for Security Incident Response Slack Client Lambda function",
         )
@@ -156,6 +158,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_client = py_lambda.PythonFunction(
             self,
             "SecurityIncidentResponseSlackClient",
+            function_name="security-incident-response-slack-client",
             entry=path.join(path.dirname(__file__), "..", "assets/slack_client"),
             runtime=aws_lambda.Runtime.PYTHON_3_13,
             timeout=Duration.minutes(15),
@@ -174,6 +177,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_client_rule = aws_events.Rule(
             self,
             "slack-client-rule",
+            rule_name="security-incident-response-slack-client-rule",
             description="Rule to send all events to Slack Lambda function",
             event_pattern=aws_events.EventPattern(source=[SECURITY_IR_EVENT_SOURCE]),
             event_bus=event_bus,
@@ -232,6 +236,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         api_gateway_logging_role = aws_iam.Role(
             self,
             "ApiGatewayLoggingRole",
+            role_name="security-incident-response-apigw-logging-role",
             assumed_by=aws_iam.ServicePrincipal("apigateway.amazonaws.com"),
             description="Role for API Gateway to write logs to CloudWatch",
             managed_policies=[
@@ -285,7 +290,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
                     aws_logs.LogGroup(
                         self,
                         "SlackApiGatewayLogs",
-                        log_group_name=f"/aws/apigateway/SlackWebhookApi-{self.node.addr}",
+                        log_group_name="/aws/apigateway/security-incident-response-slack-webhook",
                         retention=aws_logs.RetentionDays.ONE_WEEK,
                         removal_policy=RemovalPolicy.DESTROY,
                     )
@@ -334,6 +339,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_events_bolt_handler_role = aws_iam.Role(
             self,
             "SlackEventsBoltHandlerRole",
+            role_name="security-incident-response-slack-events-handler-role",
             assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
             description="Custom role for Slack Events Bolt Handler Lambda function",
         )
@@ -400,6 +406,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_events_bolt_handler = py_lambda.PythonFunction(
             self,
             "SlackEventsBoltHandler",
+            function_name="security-incident-response-slack-events-handler",
             entry=path.join(
                 path.dirname(__file__), "..", "assets/slack_events_bolt_handler"
             ),
@@ -421,6 +428,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_notifications_rule = aws_events.Rule(
             self,
             "SlackNotificationsRule",
+            rule_name="security-incident-response-slack-notifications-rule",
             description="Rule to capture events from Slack events handler",
             event_pattern=aws_events.EventPattern(source=[SLACK_EVENT_SOURCE]),
             event_bus=event_bus,
@@ -457,6 +465,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_command_handler_role = aws_iam.Role(
             self,
             "SlackCommandHandlerRole",
+            role_name="security-incident-response-slack-command-handler-role",
             assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
             description="Custom role for Slack Command Handler Lambda function",
         )
@@ -522,6 +531,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_command_handler = py_lambda.PythonFunction(
             self,
             "SlackCommandHandler",
+            function_name="security-incident-response-slack-command-handler",
             entry=path.join(
                 path.dirname(__file__), "..", "assets/slack_command_handler"
             ),

--- a/aws_security_incident_response_sample_integrations/aws_security_incident_response_slack_integration_stack.py
+++ b/aws_security_incident_response_sample_integrations/aws_security_incident_response_slack_integration_stack.py
@@ -119,7 +119,7 @@ class AwsSecurityIncidentResponseSlackIntegrationStack(Stack):
         slack_bolt_layer = aws_lambda.LayerVersion(
             self,
             "SlackBoltLayer",
-            layer_name="security-incident-response-slack-bolt-layer",
+            layer_version_name="security-incident-response-slack-bolt-layer",
             code=aws_lambda.Code.from_asset(
                 path.join(path.dirname(__file__), "..", "assets/slack_bolt_layer"),
             ),

--- a/documentation/SLACK/SLACK_CONSOLE_VERIFICATION.md
+++ b/documentation/SLACK/SLACK_CONSOLE_VERIFICATION.md
@@ -1,0 +1,185 @@
+# Slack Integration - Console Verification Guide
+
+Step-by-step guide to verify the Slack integration deployment via the AWS Console (us-east-1).
+
+---
+
+## 1. CloudFormation Stacks
+
+1. Go to **CloudFormation** → **Stacks**
+2. Verify both stacks exist and show **CREATE_COMPLETE** or **UPDATE_COMPLETE**:
+   - `AwsSecurityIncidentResponseSampleIntegrationsCommonStack`
+   - `AwsSecurityIncidentResponseSlackIntegrationStack`
+3. Click the Slack stack → **Outputs** tab → note down:
+   - `SlackWebhookUrl` (you'll need this for Slack app config)
+   - `SlackClientLambdaArn`
+
+---
+
+## 2. EventBridge - Custom Event Bus
+
+1. Go to **Amazon EventBridge** → **Event buses**
+2. Confirm `security-incident-event-bus` exists
+3. Click on it → **Rules** tab
+4. You should see rules including one that routes `security-ir` events to the Slack Client Lambda
+
+---
+
+## 3. EventBridge - Slack Client Rule
+
+1. Still on the `security-incident-event-bus` rules list, find the rule for Slack
+   - It may be named `slack-client-rule` or have a CDK-generated name like `AwsSecurityIncidentResp-slackclientruleXXXXX`
+2. Click the rule and verify:
+   - **Status**: Enabled
+   - **Event pattern** contains:
+     ```json
+     { "source": ["security-ir"] }
+     ```
+   - **Targets** tab shows a Lambda function (the Slack Client)
+3. Click the target Lambda ARN → confirm it opens the correct Slack Client function
+
+---
+
+## 4. EventBridge - Security IR Client Rule
+
+1. Back on the `security-incident-event-bus` rules list, find the rule for the Security IR Client
+   - Look for a rule with event pattern containing `"source": ["jira", "service-now", "slack"]`
+2. Click the rule and verify:
+   - **Status**: Enabled
+   - **Targets** tab shows the Security IR Client Lambda
+3. This rule is what routes Slack-originated events back to AWS Security IR
+
+---
+
+## 5. EventBridge - Poller Schedule Rule
+
+1. Go to **Amazon EventBridge** → **Rules** (on the **default** event bus)
+2. Find the poller rule (name contains `SecurityIncidentResponsePollerRule` or similar)
+3. Verify:
+   - **Schedule**: `rate(1 minute)` or `rate(5 minutes)`
+   - **Status**: ENABLED (or DISABLED if no cases are active yet — this is normal for initial deploy)
+   - **Targets**: Points to the Security IR Poller Lambda
+
+---
+
+## 6. Lambda Functions
+
+1. Go to **Lambda** → **Functions**
+2. Find and verify each function is in **Active** state:
+
+| Function (name contains) | Purpose | Key Env Vars to Check |
+|---|---|---|
+| `SecurityIncidentResponsePoller` | Polls SIR for cases | `INCIDENTS_TABLE_NAME`, `EVENT_BUS_NAME` |
+| `SecurityIncidentResponseSlackClient` | Creates Slack channels, posts updates | `SLACK_BOT_TOKEN`, `INCIDENTS_TABLE_NAME` |
+| `SlackEventsBoltHandler` | Receives Slack webhook events | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET` |
+| `SlackCommandHandler` | Processes `/security-ir` commands | `SLACK_BOT_TOKEN`, `INCIDENTS_TABLE_NAME` |
+| `SecurityIncidentResponseClient` | Updates SIR from external events | `INCIDENTS_TABLE_NAME` |
+
+3. For each function, click → **Configuration** tab → **Environment variables**
+   - Verify `INCIDENTS_TABLE_NAME` matches your DynamoDB table name
+   - Verify `EVENT_BUS_NAME` is `security-incident-event-bus` (where applicable)
+
+---
+
+## 7. Lambda - Poller IAM Permissions
+
+1. Click the **SecurityIncidentResponsePoller** function
+2. Go to **Configuration** → **Permissions** → click the **Role name**
+3. In IAM, expand the inline policies
+4. Verify the policy includes:
+   - `security-ir:GetCase`
+   - `security-ir:ListCases`
+   - `security-ir:ListComments`
+   - `security-ir:GetMembership` ← needed for team member merge
+   - `security-ir:ListMemberships` ← needed for team member merge
+   - `events:PutEvents`
+   - `events:PutRule` (for adaptive polling)
+5. Also verify DynamoDB read/write access to the incidents table
+
+---
+
+## 8. DynamoDB Table
+
+1. Go to **DynamoDB** → **Tables**
+2. Find the table (name contains `IncidentsTable`)
+3. Verify:
+   - **Status**: Active
+   - **Partition key**: `PK` (String)
+   - **Sort key**: `SK` (String)
+   - **Billing mode**: On-demand
+4. If cases have been processed, click **Explore table items** and check for items with `PK` starting with `Case#`
+
+---
+
+## 9. SSM Parameters
+
+1. Go to **Systems Manager** → **Parameter Store**
+2. Verify these parameters exist:
+   - `/SecurityIncidentResponse/slackBotToken`
+   - `/SecurityIncidentResponse/slackSigningSecret`
+   - `/SecurityIncidentResponse/slackWorkspaceId`
+3. You can click each to confirm it has a value (don't share the token/secret values)
+
+---
+
+## 10. API Gateway
+
+1. Go to **API Gateway** → **APIs**
+2. Find the Slack Webhook API (name contains `Slack` or `slack`)
+3. Click it → **Stages** → `prod`
+4. Note the **Invoke URL** — this should match the `SlackWebhookUrl` from CloudFormation outputs
+5. Go to **Resources** → verify you see:
+   - `/slack/events` with a **POST** method
+6. Click the POST method → verify **Integration type** is `Lambda Function` and it points to the Bolt Handler
+
+---
+
+## 11. CloudWatch Logs
+
+1. Go to **CloudWatch** → **Log groups**
+2. Verify log groups exist for each Lambda (created on first invocation):
+   - Look for groups containing `SecurityIncidentResponsePoller`
+   - Look for groups containing `SlackClient`
+   - Look for groups containing `SlackEventsBoltHandler`
+3. Also check the EventBridge log group:
+   - `/aws/events/security-incident-event-bus`
+   - This logs all events flowing through the bus (useful for debugging)
+
+---
+
+## 12. End-to-End Wiring Summary
+
+Verify this flow is connected:
+
+```
+┌──────────────┐      ┌───────────────────────────┐      ┌──────────────┐
+│ SIR Poller   │─────►│ EventBridge               │─────►│ Slack Client │
+│ (scheduled)  │      │ (security-ir source)      │      │ (creates ch) │
+└──────────────┘      └───────────────────────────┘      └──────────────┘
+
+┌──────────────┐      ┌───────────────────────────┐      ┌──────────────┐
+│ Slack Events │─────►│ API Gateway + Bolt Handler│─────►│ EventBridge  │
+│ (webhooks)   │      │ (posts to event bus)      │      │ (slack src)  │
+└──────────────┘      └───────────────────────────┘      └──────────────┘
+                                                                │
+                                                                ▼
+                                                         ┌──────────────┐
+                                                         │ SIR Client   │
+                                                         │ (updates SIR)│
+                                                         └──────────────┘
+```
+
+**Quick check**: If the Poller is enabled and there are active SIR cases, you should see:
+- Events in the `/aws/events/security-incident-event-bus` log group
+- Slack channels being created in your workspace
+
+---
+
+## Troubleshooting the "slack-client-rule: Not found" Error
+
+The verification script looks for a rule named exactly `slack-client-rule` on `security-incident-event-bus`. CDK may generate a different physical name.
+
+1. Go to **EventBridge** → **Event buses** → `security-incident-event-bus` → **Rules**
+2. Look for any rule with event pattern `{"source": ["security-ir"]}`
+3. If you find it under a different name, the integration works fine — the verification script just uses a hardcoded name lookup
+4. If NO rule matches that pattern, the Slack stack may need redeployment


### PR DESCRIPTION
Add explicit fixed names to all CDK resources across the Common and Slack integration stacks. Previously, CDK auto-generated resource names with hash suffixes (e.g., `AwsSecurityIncidentRespon-SecurityIncidentResponse-l7UM3Uqie77B`), making them difficult to identify in the AWS Console and CLI.

Resources now have predictable names like:
- `security-incident-response-poller-function`
- `security-incident-response-slack-client`
- `security-incident-response-client-rule`
- `security-incident-response-incidents-table`

Also includes a console verification guide for the Slack integration deployment.

## Type of change (Choose 1)

- [ ] Bug Fix
- [x] New Feature: Non-new Integration Target
- [ ] New Feature: New Integration Target
- [x] Documentation update
- [ ] Security fix

## Reason for this change

CDK-generated resource names with hash suffixes are difficult to identify when debugging in the AWS Console, writing IAM policies, or referencing resources in monitoring/alerting. Fixed names improve operational visibility and make it easier for teams to locate and manage deployed resources.

## Related Issue (if applicable)

N/A

## Contributor Task List

- [x] I have reviewed the [Contributing Guideline](../CONTRIBUTING.md) and [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] The code coverage difference report check has passed
- [x] Security considerations have been addressed